### PR TITLE
Updating name and link for associated Katacoda scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This project contains some simple, generic Java code in a Gradle project used to demonstrate building Java into a container.
 
-See the Katacoda scenario for [Distillation Pattern with the JRE](https://www.katacoda.com/javajon/courses/kubernetes-fundamentals/distillation) to learn how it's used.
+See the Katacoda scenario for [Distilled JRE Apps in Containers](https://www.katacoda.com/javajon/courses/kubernetes-containers/distillation) to learn how it's used.
 
 The code was inspired from the related article [GraalVM: Native Images in Containers](https://blogs.oracle.com/javamagazine/graalvm-native-images-in-containers) by [Oleg Šelajev](https://github.com/shelajev).


### PR DESCRIPTION
Updated README based upon scenario presented for the St. Louis Java User Group (April 2020).  

@javajon You'll still want to correct the link within the repository description as well.